### PR TITLE
Remove TIMES model version references from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# TIMES-NZ 2.0 Data Visualization App
-This repository contains the README, source code and data behind the TIMES-NZ 2.0 visualisation tool. The app is located on the [shinyapps.io](https://shinyapps.io) platform [here](https://eeca-nz.shinyapps.io/TIMES_V2/) and it can be viewed through [EECA's website](http://www.eeca.govt.nz/TIMES-NZ).
+# TIMES-NZ Data Visualization App
+This repository contains the README, source code and data behind the TIMES-NZ visualisation tool. The app is located on the [shinyapps.io](https://shinyapps.io) platform [here](https://eeca-nz.shinyapps.io/TIMES_V2/) and it can be viewed through [EECA's website](http://www.eeca.govt.nz/TIMES-NZ).
 
 ## Background
-The New Zealand Energy Scenarios Times-NZ 2.0 website presents model insights for the latest TIMES-NZ scenarios to contribute to decision making by businesses and Government. The New Zealand Energy Scenarios TIMES-NZ 2.0 visualisation tool allows users to explore how New Zealand energy futures may look like based on outputs from the New Zealand Energy Scenarios TIMES-NZ 2.0 model. A detailed description of the  model and the app is found on the [EECA website](https://www.eeca.govt.nz/New-Zealand-Energy-Scenarios-TIMES-NZ-2.pdf).
+The New Zealand Energy Scenarios Times-NZ website presents model insights for the latest TIMES-NZ scenarios to contribute to decision making by businesses and Government. The New Zealand Energy Scenarios TIMES-NZ visualisation tool allows users to explore how New Zealand energy futures may look like based on outputs from the New Zealand Energy Scenarios TIMES-NZ model. A detailed description of the  model and the app is found on the [EECA website](https://www.eeca.govt.nz/New-Zealand-Energy-Scenarios-TIMES-NZ-2.pdf).
 
 ## Software requirements
 - [R (v4+)](https://cran.r-project.org/bin/windows/base/)


### PR DESCRIPTION
Removed references to model versions, e.g. 2.0. These aren't useful and could easily be out of date.

Could someone please review my assumption that these aren't needed. A link to the model repo would be better. And maybe a tagged version if it only supports one version.